### PR TITLE
Blog/Pinnwand Refactor

### DIFF
--- a/src/lmu/contenttypes/pinnwand/browser/configure.zcml
+++ b/src/lmu/contenttypes/pinnwand/browser/configure.zcml
@@ -27,6 +27,13 @@
         />
 
     <browser:page
+        for="lmu.contenttypes.pinnwand.interfaces.IPinnwandEntry"
+        name="edit"
+        permission="cmf.ModifyPortalContent"
+        class=".views.PinnwandEntryEditForm"
+        />
+
+    <browser:page
         name="report_innwand_entry"
         for="lmu.contenttypes.pinnwand.interfaces.IPinnwandEntry"
         permission="zope2.View"

--- a/src/lmu/contenttypes/pinnwand/browser/templates/entry_view.pt
+++ b/src/lmu/contenttypes/pinnwand/browser/templates/entry_view.pt
@@ -77,13 +77,13 @@
                        i18n:translate="" >Report pinnwand Entry</a> 
 
                     <a tal:attributes="href string:${context/absolute_url}/edit" 
-                       tal:condition="view/canEdit"
+                       tal:condition="view/can_edit"
                        class="button link-overlay small"
                        title="Edit Pinnwand Entry" 
                        i18n:translate="" >Edit pinnwand Entry</a> 
 
                     <a tal:attributes="href string:${context/absolute_url}/delete_confirmation" 
-                       tal:condition="view/canRemove"
+                       tal:condition="view/can_remove"
                        class="button link-overlay small"
                        title="Delete Pinnwand Entry" 
                        i18n:translate="" >Delete pinnwand Entry</a> 
@@ -95,7 +95,7 @@
                        i18n:translate="" >Set Private</a> 
 
                     <a tal:attributes="href string:${context/absolute_url}/report_pinnwand_entry" 
-                       tal:condition="view/canLock"
+                       tal:condition="view/can_lock"
                        class="button link-overlay small"
                        title="Report Pinnwand Entry" 
                        i18n:translate="" >Sperren</a> 

--- a/src/lmu/contenttypes/pinnwand/browser/templates/frontpage_view.pt
+++ b/src/lmu/contenttypes/pinnwand/browser/templates/frontpage_view.pt
@@ -157,7 +157,7 @@
   </div>
 </div>
 
-<footer id="pinnwand-footer" class="row overview-light" tal:condition="not: view/author | view/canAdd">
+<footer id="pinnwand-footer" class="row overview-light" tal:condition="not: view/author | view/can_add">
   <div class="columns  small-12 large-10 large-centered">
     <a class="button link-overlay small-12"
        tal:define="add_url string:${context/absolute_url}/++add++Pinnwand Entry;"

--- a/src/lmu/contenttypes/pinnwand/browser/templates/listing_view.pt
+++ b/src/lmu/contenttypes/pinnwand/browser/templates/listing_view.pt
@@ -26,7 +26,7 @@
           <a class="button small-12"
              tal:define="add_url string:${context/absolute_url}/++add++Pinnwand Entry;"
              tal:attributes="href add_url;"
-             tal:condition="view/canAdd"
+             tal:condition="view/can_add"
              i18n:translate="">
             Jetzt einen Pinnwand-Beitrag verfassen
           </a>
@@ -113,7 +113,7 @@
         </div>
       </div>
       <footer id="pinnwand-footer" class="row"
-              tal:condition="view/canAdd">
+              tal:condition="view/can_add">
         <div class="columns small-12 large-10 large-centered">
           <a class="button small-12"
              tal:define="add_url string:${context/absolute_url}/++add++Pinnwand Entry;"

--- a/src/lmu/contenttypes/pinnwand/browser/templates/pinnwand_entry_edit.pt
+++ b/src/lmu/contenttypes/pinnwand/browser/templates/pinnwand_entry_edit.pt
@@ -1,0 +1,22 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+     xmln:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="lmu.contenttypes.blog">
+
+    <metal:block fill-slot="main">
+        <div id="content-core">
+            <metal:block use-macro="context/@@ploneform-macros/titlelessform">
+                <metal:block fill-slot="fields">
+                    <metal:block use-macro="context/@@ploneform-macros/fields" />
+
+                    <div tal:replace="structure context/@@content_view" >Content View</div>
+
+                </metal:block>
+            </metal:block>
+        </div>
+
+    </metal:block>
+
+</html>

--- a/src/lmu/contenttypes/pinnwand/browser/views.py
+++ b/src/lmu/contenttypes/pinnwand/browser/views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from Products.CMFCore import permissions
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from plone import api
@@ -9,6 +8,7 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 
 from lmu.contenttypes.pinnwand.interfaces import IPinnwandFolder
 from lmu.policy.base.browser import _AbstractLMUBaseContentView
+from lmu.policy.base.browser import _AbstractLMUBaseListingView
 from lmu.policy.base.browser import _FrontPageIncludeMixin
 from lmu.policy.base.browser import _EntryViewMixin
 
@@ -17,47 +17,33 @@ def str2bool(v):
     return v is not None and v.lower() in ['true', '1']
 
 
-class _AbstractPinnwandListingView(_AbstractLMUBaseContentView):
-
-    def entries(self):
-        entries = []
-        if IPinnwandFolder.providedBy(self.context):
-            content_filter = {
-                'portal_type': 'Pinnwand Entry',
-                #'review_state': ['published', 'internal-published', 'internally_published'],
-            }
-            if self.request.get('author'):
-                content_filter['Creator'] = self.request.get('author')
-
-            pcatalog = self.context.portal_catalog
-
-            entries = pcatalog.searchResults(
-                content_filter,
-                sort_on='modified', sort_order='reverse',
-                b_size=int(self.request.get('b_size', '20')),
-                b_start=int(self.request.get('b_start', '0'))
-            )
-
-        return entries
-
-    def canAdd(self):
-        #current_user = api.user.get_current()
-        #import ipdb; ipdb.set_trace()
-        #return api.user.has_permission(permissions.AddPortalContent, user=current_user, obj=self.context)
-        return api.user.has_permission(permissions.AddPortalContent, obj=self.context)
-
-
-class ListingView(_AbstractPinnwandListingView):
+class ListingView(_AbstractLMUBaseListingView):
 
     template = ViewPageTemplateFile('templates/listing_view.pt')
+
+    DEFAULT_LIMIT = 20
+    portal_type = 'Pinnwand Entry'
+    container_interface = IPinnwandFolder
+    sort_on = 'modified'
+
+    def __init__(self, context, request):
+        super(ListingView, self).__init__(context, request)
+
+        if self.request.get('author'):
+            self.content_filter['Creator'] = self.request.get('author')
 
     def __call__(self):
         return self.template()
 
 
-class FrontPageIncludeView(_AbstractPinnwandListingView, _FrontPageIncludeMixin):
+class FrontPageIncludeView(_AbstractLMUBaseListingView, _FrontPageIncludeMixin):
 
     template = ViewPageTemplateFile('templates/frontpage_view.pt')
+
+    DEFAULT_LIMIT = 20
+    portal_type = 'Pinnwand Entry'
+    container_interface = IPinnwandFolder
+    sort_on = 'modified'
 
 
 class EntryView(_AbstractLMUBaseContentView, _EntryViewMixin):

--- a/src/lmu/contenttypes/pinnwand/browser/views.py
+++ b/src/lmu/contenttypes/pinnwand/browser/views.py
@@ -6,7 +6,9 @@ from plone import api
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
+from lmu.contenttypes.blog import MESSAGE_FACTORY as _  # XXX move translations
 from lmu.contenttypes.pinnwand.interfaces import IPinnwandFolder
+from lmu.policy.base.browser import _AbstractLMUBaseContentEditForm
 from lmu.policy.base.browser import _AbstractLMUBaseContentView
 from lmu.policy.base.browser import _AbstractLMUBaseListingView
 from lmu.policy.base.browser import _FrontPageIncludeMixin
@@ -52,6 +54,14 @@ class EntryView(_AbstractLMUBaseContentView, _EntryViewMixin):
 
     def __call__(self):
         return self.template()
+
+
+class PinnwandEntryEditForm(_AbstractLMUBaseContentEditForm):
+    template = ViewPageTemplateFile('templates/pinnwand_entry_edit.pt')
+
+    description = _(u'Bearbeiten Sie Ihren Pinnwand-Beitrag. Klicken Sie anschließend auf "Vorschau", um die Eingaben zu überprüfen und den Blog-Eintrag zu veröffentlichen.')
+
+    portal_type = 'Pinnwand Entry'
 
 
 @provider(IContextAwareDefaultFactory)

--- a/src/lmu/contenttypes/pinnwand/browser/views.py
+++ b/src/lmu/contenttypes/pinnwand/browser/views.py
@@ -8,11 +8,11 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 
 from lmu.contenttypes.blog import MESSAGE_FACTORY as _  # XXX move translations
 from lmu.contenttypes.pinnwand.interfaces import IPinnwandFolder
-from lmu.policy.base.browser import _AbstractLMUBaseContentEditForm
-from lmu.policy.base.browser import _AbstractLMUBaseContentView
-from lmu.policy.base.browser import _AbstractLMUBaseListingView
-from lmu.policy.base.browser import _FrontPageIncludeMixin
-from lmu.policy.base.browser import _EntryViewMixin
+from lmu.policy.base.browser.content import _AbstractLMUBaseContentEditForm
+from lmu.policy.base.browser.content import _AbstractLMUBaseContentView
+from lmu.policy.base.browser.content import _EntryViewMixin
+from lmu.policy.base.browser.content_listing import _AbstractLMUBaseListingView
+from lmu.policy.base.browser.content_listing import _FrontPageIncludeMixin
 
 
 def str2bool(v):

--- a/src/lmu/contenttypes/pinnwand/content.py
+++ b/src/lmu/contenttypes/pinnwand/content.py
@@ -8,7 +8,6 @@ from Products.statusmessages.interfaces import IStatusMessage
 from plone.dexterity.content import Container
 
 #from plone.app.contenttypes.behaviors.leadimage import ILeadImage
-from plone.app.discussion.interfaces import IConversation
 from plone.directives import form
 
 from zope.interface import implements
@@ -23,6 +22,7 @@ from lmu.contenttypes.pinnwand.interfaces import IPinnwandEntry
 from lmu.contenttypes.pinnwand.interfaces import IPinnwandReportForm
 
 from lmu.contenttypes.pinnwand import MessageFactory as _
+from lmu.policy.base.content import LMUBaseContent
 
 
 pinnwand_entry_types_vocabulary = SimpleVocabulary([
@@ -35,17 +35,8 @@ class PinnwandFolder(Container):
     implements(IPinnwandFolder, ISyndicatable)
 
 
-class PinnwandEntry(Container):
+class PinnwandEntry(LMUBaseContent):
     implements(IPinnwandEntry)
-
-    def getDiscussionCount(self):
-        try:
-            # plone.app.discussion.conversation object
-            # fetched via IConversation adapter
-            conversation = IConversation(self)
-        except:
-            return 0
-        return conversation.total_comments
 
 
 class PinnwandReportForm(form.SchemaForm):

--- a/src/lmu/contenttypes/pinnwand/interfaces.py
+++ b/src/lmu/contenttypes/pinnwand/interfaces.py
@@ -8,21 +8,23 @@ from plone.namedfile.interfaces import IImageScaleTraversable
 from plone.theme.interfaces import IDefaultPloneLayer
 
 from zope import schema
+from zope.interface import Interface
 
 #from zope.interface import Attribute
 #from zope.interface import Interface
 
+from lmu.policy.base.interfaces import ILMUContent
 from lmu.contenttypes.pinnwand import MessageFactory as _
 
 
-class IPinnwandFolder(form.Schema, IImageScaleTraversable):
+class IPinnwandFolder(Interface, IImageScaleTraversable):
     """
     Folder for Pinnwand Entries with special views and restrictions
     """
     form.model("models/pinnwand_folder.xml")
 
 
-class IPinnwandEntry(form.Schema, IImageScaleTraversable):
+class IPinnwandEntry(ILMUContent, IImageScaleTraversable):
     """
     Pinnwand Entry with folder support for files and images
     """


### PR DESCRIPTION
Achtung, hängt ab von diesem Pull-Request, bitte zuerst mergen:

https://github.com/loechel/lmu.policy.base/pull/14

Verwende Code aus der Policy wieder, so dass Pinnwand-Einträge sich ähnlich wie Blog-Einträge verhalten.

Es gibt noch keine custom Add-Form; ich hatte noch im Kopf, dass andere Felder versteckt sein sollen als beim Blog, aber war über die Details nicht mehr sicher. Sollte leicht noch nachtragbar sein.

Die Frontpage-View sieht im Prinzip aus wie vorher, was (wenn ich es richtig verstanden habe) ja auch gewollt ist.
